### PR TITLE
feat: bump torch to 2.1. remove python 3.9 build [EN-10375]

### DIFF
--- a/dev/packaging/build_all_wheels.sh
+++ b/dev/packaging/build_all_wheels.sh
@@ -26,7 +26,7 @@ build_one() {
   echo "Launching container $container_name ..."
   container_id="$container_name"_"$cu"_"$pytorch_ver"
 
-  py_versions=(3.9 3.10 3.11)
+  py_versions=(3.10 3.11)
 
   for py in "${py_versions[@]}"; do
     docker run -itd \
@@ -49,5 +49,5 @@ EOF
 if [[ -n "$1" ]] && [[ -n "$2" ]]; then
   build_one "$1" "$2"
 else
-  build_one cu118 2.0
+  build_one cu118 2.1
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "torch==1.10.2+cu113"]
+requires = ["setuptools", "wheel", "numpy", "torch==2.1.0+cu118"]


### PR DESCRIPTION
- Bump torch to 2.1
- Remove python 3.9 build as we will not revert to this python version 

